### PR TITLE
Write verbose feed too

### DIFF
--- a/emoji-tracker/index.js
+++ b/emoji-tracker/index.js
@@ -68,11 +68,13 @@ async function main() {
   }
 
   const rss = buildRss(now, newEmojis, new Date(previousMetadata.updated));
+  const rssVerbose = buildRssVerbose(now, newEmojis, new Date(previousMetadata.updated))
 
   await writeToS3(Bucket, `${process.env.SLACK_WORKSPACE}-emojis-metadata.json`, JSON.stringify({
     emojis: latestEmojis,
     updated: now.getTime()
   }));
+  await writeToS3(Bucket, `${process.env.SLACK_WORKSPACE}-emojis-verbose.rss`, rssVerbose);
   await writeToS3(Bucket, `${process.env.SLACK_WORKSPACE}-emojis.rss`, rss);
 
   return 0;

--- a/emoji-tracker/rss.js
+++ b/emoji-tracker/rss.js
@@ -6,7 +6,7 @@ const template = ({
 }) => `<?xml version="1.0" encoding="UTF-8" ?>
 <rss version="2.0">
 <channel>
- <title>New Emojis</title>
+ <title>New ${process.env.SLACK_WORKSPACE} Emojis</title>
  <description>Coolkev's ${process.env.SLACK_WORKSPACE} "New Emojis" RSS feed</description>
  <link>https://${process.env.SLACK_WORKSPACE}.slack.com/customize/emoji</link>
  <lastBuildDate>${now.toUTCString()}</lastBuildDate>
@@ -15,10 +15,37 @@ const template = ({
 
   <item>
   <title>
-    New emojis since ${previousUpdateTime.toUTCString()}
+    New emojis since ${previousUpdateTime.toLocaleString()}
   </title>
   <description>${newEmojis.map(emoji => `:${emoji}:`).join(" ")}</description>
-  <link>https://${process.env.SLACK_WORKSPACE}.slack.com/customize/emoji}</link>
+  <link>https://${process.env.SLACK_WORKSPACE}.slack.com/customize/emoji</link>
+  <pubDate>${pubDate.toUTCString()}</pubDate>
+  </item>
+
+</channel>
+</rss>`;
+
+const verboseTemplate = ({
+  now,
+  pubDate,
+  newEmojis,
+  previousUpdateTime
+}) => `<?xml version="1.0" encoding="UTF-8" ?>
+<rss version="2.0">
+<channel>
+ <title>New ${process.env.SLACK_WORKSPACE} Emojis</title>
+ <description>Coolkev's ${process.env.SLACK_WORKSPACE} "New Emojis" RSS feed</description>
+ <link>https://${process.env.SLACK_WORKSPACE}.slack.com/customize/emoji</link>
+ <lastBuildDate>${now.toUTCString()}</lastBuildDate>
+ <pubDate>${pubDate.toUTCString()}</pubDate>
+ <ttl>10</ttl>
+
+  <item>
+  <title>
+    New emojis since ${previousUpdateTime.toLocaleString()}
+  </title>
+  <description>${newEmojis.map(emoji => `\`${emoji}\`: :${emoji}:`).join("\n")}</description>
+  <link>https://${process.env.SLACK_WORKSPACE}.slack.com/customize/emoji</link>
   <pubDate>${pubDate.toUTCString()}</pubDate>
   </item>
 
@@ -33,6 +60,16 @@ const buildRss = (now, newEmojis, previousUpdateTime) => {
   pubDate.setMilliseconds(0);
 
   return template({ pubDate, now, newEmojis, previousUpdateTime });
+};
+
+const buildRssVerbose = (now, newEmojis, previousUpdateTime) => {
+  const pubDate = new Date(now);
+  // pubDate.setHours(7);
+  // pubDate.setMinutes(0);
+  pubDate.setSeconds(0);
+  pubDate.setMilliseconds(0);
+
+  return verboseTemplate({ pubDate, now, newEmojis, previousUpdateTime });
 };
 
 module.exports = {


### PR DESCRIPTION
* Adds a new verbose feed with a different format:
  ```
  ${newEmojis.map(emoji => `\`${emoji}\`: :${emoji}:`).join("\n")}
  ```
* Updates title to have the slack workspace included.
* Fixes the link to not have a trailing `}` character.

